### PR TITLE
Fix MangaDex, remove the "none" function

### DIFF
--- a/src/MangaDex/MangaDex.ts
+++ b/src/MangaDex/MangaDex.ts
@@ -52,7 +52,7 @@ export const MangaDexInfo: SourceInfo = {
     description: 'Extension that pulls manga from MangaDex',
     icon: 'icon.png',
     name: 'MangaDex',
-    version: '2.0.6',
+    version: '2.0.7',
     authorWebsite: 'https://github.com/nar1n',
     websiteBaseURL: MANGADEX_DOMAIN,
     contentRating: ContentRating.EVERYONE,

--- a/src/MangaDex/MangaDexHelper.ts
+++ b/src/MangaDex/MangaDexHelper.ts
@@ -289,16 +289,10 @@ interface Demographic {
 class MDDemographicsClass {
     Demographics: Demographic[] = [
         {
-            name: 'Unknown',
-            enum: 'none',
-            default: true
-        },
-        {
             name: 'Safe',
             enum: 'safe',
             default: true
-        }
-        ,
+        },
         {
             name: 'Suggestive',
             enum: 'suggestive',


### PR DESCRIPTION
New MangaDex API changes, none is no longer a valid input and will cause an 400 page on request.
Context: https://discord.com/channels/673606787290759230/705193595715452958/864936293620121620